### PR TITLE
Feat/proxy notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,5 @@ $ ./build/webhook-consumer
 
 ## Usage
 
-At this time, just a simple notification method was implemented (stdout).
+At this time, just a simple notifier was implemented (stdout).
 After start the webhook, is possible to make a call and the data will be printed on the stdout.
-
-```bash
-curl -i -X POST localhost:3000/api/v0/notifications -d '{"text":"aaa456"}'
-```

--- a/cmd/define_notifiers.go
+++ b/cmd/define_notifiers.go
@@ -27,7 +27,7 @@ func defineNotifiers(cfg *configuration.Config, log *logrus.Logger) ([]domain.No
 	result := []domain.Notifier{}
 
 	for _, notifier := range notifiersToConfig {
-		impl, _ := notificationTypes[notifier]
+		impl := notificationTypes[notifier]
 		if err := impl.Configure(cfg, log); err != nil {
 			return nil, fmt.Errorf("configure failed in [%s] notifier: %v", notifier, err)
 		}

--- a/cmd/define_notifiers.go
+++ b/cmd/define_notifiers.go
@@ -11,14 +11,14 @@ import (
 	"github.com/stone-co/webhook-consumer/pkg/gateways/notifiers/stdout"
 )
 
-func defineNotifiers(cfg *configuration.Config, log *logrus.Logger) ([]domain.NotifierMethod, error) {
+func defineNotifiers(cfg *configuration.Config, log *logrus.Logger) ([]domain.Notifier, error) {
 
 	type notifierInfo struct {
-		notifier domain.NotifierMethod
+		notifier domain.Notifier
 		used     bool
 	}
 
-	// Stdout method is used only to debug purpose.
+	// Stdout notifier is used only to debug purpose.
 	var notificationTypes = map[string]notifierInfo{
 		"stdout": {
 			notifier: stdout.New(log),
@@ -28,7 +28,7 @@ func defineNotifiers(cfg *configuration.Config, log *logrus.Logger) ([]domain.No
 		},
 	}
 
-	result := []domain.NotifierMethod{}
+	result := []domain.Notifier{}
 
 	for _, notifier := range strings.Split(cfg.NotifierList, ";") {
 		notifier = strings.TrimSpace(notifier)

--- a/cmd/define_notifiers.go
+++ b/cmd/define_notifiers.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stone-co/webhook-consumer/pkg/domain"
+	"github.com/stone-co/webhook-consumer/pkg/gateways/notifiers/stdout"
+)
+
+func defineNotifiers(log *logrus.Logger, notifiers string) ([]domain.NotifierMethod, error) {
+
+	type notifierInfo struct {
+		notifier domain.NotifierMethod
+		used     bool
+	}
+
+	// Stdout method is used only to debug purpose.
+	var notificationTypes = map[string]notifierInfo{
+		"stdout": {
+			notifier: stdout.New(log),
+		},
+		"proxyapi": {
+			notifier: stdout.New(log),
+		},
+	}
+
+	result := []domain.NotifierMethod{}
+
+	for _, notifier := range strings.Split(notifiers, ";") {
+		notifier = strings.TrimSpace(notifier)
+		if notifier == "" {
+			continue
+		}
+
+		notifier = strings.ToLower(notifier)
+		info, ok := notificationTypes[notifier]
+		if !ok {
+			return nil, fmt.Errorf("undefined notifier: %v", notifier)
+		}
+
+		if info.used {
+			return nil, fmt.Errorf("duplicated notifier: %v", notifier)
+		}
+
+		info.used = true
+		notificationTypes[notifier] = info
+
+		result = append(result, info.notifier)
+	}
+
+	if len(result) == 0 {
+		return nil, fmt.Errorf("empty notifier list")
+	}
+
+	return result, nil
+}

--- a/cmd/define_notifiers_test.go
+++ b/cmd/define_notifiers_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_extractNotifiersFromConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "Valid config with one notifier",
+			args: "stdout",
+			want: []string{"stdout"},
+		},
+		{
+			name: "Valid config with two notifiers",
+			args: "stdout;proxy",
+			want: []string{"stdout", "proxy"},
+		},
+		{
+			name: "Config is case insensitive",
+			args: "stDOut;PROxy",
+			want: []string{"stdout", "proxy"},
+		},
+		{
+			name: "Spaces all trimmed when necessary",
+			args: "      stdout   ;     proxy     ",
+			want: []string{"stdout", "proxy"},
+		},
+		{
+			name: "Extra ';' are ignored",
+			args: ";;      stdout   ;    ; proxy  ;   ",
+			want: []string{"stdout", "proxy"},
+		},
+		{
+			name:    "Empty config must fail",
+			args:    "",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Invalid notifier must fail",
+			args:    "xpto;stdout",
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Duplicate notifier must fail",
+			args:    "stdout;stdout",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := extractNotifiersFromConfig(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractNotifiersFromConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractNotifiersFromConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,7 +23,9 @@ func main() {
 		log.WithError(err).Fatal("unable to load app configuration")
 	}
 
-	// Stdout method only in this PR.
+	log.Infof("config: %s", cfg)
+
+	// Stdout method is used only to debug purpose.
 	method := stdout.New(log)
 
 	usecase := usecase.NewNotificationUsecase(log, method)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,7 +35,7 @@ func main() {
 		log.WithError(err).Fatalf("unable to define notifiers: %v", err)
 	}
 
-	usecase := usecase.NewNotificationUsecase(log, notifiers)
+	usecase := usecase.NewNotificationUsecase(log, keys, notifiers)
 
 	// Make a channel to listen for an interrupt or terminate signal from the OS.
 	// Use a buffered channel because the signal package requires it.
@@ -47,7 +47,7 @@ func main() {
 	serverErrors := make(chan error, 1)
 
 	// NewServer HTTP Server listening for requests.
-	httpServer := http.NewHttpServer(*cfg, keys, log, usecase)
+	httpServer := http.NewHttpServer(*cfg, log, usecase)
 	go func() {
 		log.Infof("starting http api at %s", httpServer.Addr)
 		serverErrors <- httpServer.ListenAndServe()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/stone-co/webhook-consumer/pkg/common/configuration"
+	"github.com/stone-co/webhook-consumer/pkg/common/keys"
 	"github.com/stone-co/webhook-consumer/pkg/domain/usecase"
 	"github.com/stone-co/webhook-consumer/pkg/gateways/http"
 )
@@ -23,6 +24,11 @@ func main() {
 	}
 
 	log.Infof("config: %s", cfg)
+
+	keys, err := keys.LoadKeys(cfg.PrivateKeyPath, cfg.PublicKeyLocation)
+	if err != nil {
+		log.WithError(err).Fatal("unable to load keys")
+	}
 
 	notifiers, err := defineNotifiers(cfg, log)
 	if err != nil {
@@ -41,7 +47,7 @@ func main() {
 	serverErrors := make(chan error, 1)
 
 	// NewServer HTTP Server listening for requests.
-	httpServer := http.NewHttpServer(*cfg, log, usecase)
+	httpServer := http.NewHttpServer(*cfg, keys, log, usecase)
 	go func() {
 		log.Infof("starting http api at %s", httpServer.Addr)
 		serverErrors <- httpServer.ListenAndServe()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stone-co/webhook-consumer/pkg/common/configuration"
 	"github.com/stone-co/webhook-consumer/pkg/domain/usecase"
 	"github.com/stone-co/webhook-consumer/pkg/gateways/http"
-	"github.com/stone-co/webhook-consumer/pkg/gateways/notifiers/stdout"
 )
 
 func main() {
@@ -25,10 +24,12 @@ func main() {
 
 	log.Infof("config: %s", cfg)
 
-	// Stdout method is used only to debug purpose.
-	method := stdout.New(log)
+	notifiers, err := defineNotifiers(log, cfg.NotifierList)
+	if err != nil {
+		log.WithError(err).Fatalf("unable to define notifiers: %v", err)
+	}
 
-	usecase := usecase.NewNotificationUsecase(log, method)
+	usecase := usecase.NewNotificationUsecase(log, notifiers)
 
 	// Make a channel to listen for an interrupt or terminate signal from the OS.
 	// Use a buffered channel because the signal package requires it.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	log.Infof("config: %s", cfg)
 
-	notifiers, err := defineNotifiers(log, cfg.NotifierList)
+	notifiers, err := defineNotifiers(cfg, log)
 	if err != nil {
 		log.WithError(err).Fatalf("unable to define notifiers: %v", err)
 	}

--- a/pkg/common/configuration/config.go
+++ b/pkg/common/configuration/config.go
@@ -29,11 +29,17 @@ type Config struct {
 	// To specify a URL: "url://https://sandbox-api.openbank.stone.com.br/api/v1/discovery/keys"
 	PublicKeyLocation   string `envconfig:"PUBLIC_KEY_PATH" default:"url://https://sandbox-api.openbank.stone.com.br/api/v1/discovery/keys"`
 	VerificationKeyList []*jose.JSONWebKey
+	NotifierList        string `envconfig:"NOTIFIER_LIST" default:"stdout"`
+	ProxyNotifier       ProxyNotifierConfig
 }
 
 type HTTPConfig struct {
 	Port            int           `envconfig:"API_PORT" default:"3000"`
 	ShutdownTimeout time.Duration `envconfig:"API_SHUTDOWN_TIMEOUT" default:"5s"`
+}
+
+type ProxyNotifierConfig struct {
+	APIUrl string `envconfig:"PROXY_NOTIFIER_API_URL"`
 }
 
 func LoadConfig() (*Config, error) {
@@ -63,8 +69,8 @@ func LoadConfig() (*Config, error) {
 }
 
 func (cfg Config) String() string {
-	return fmt.Sprintf("port:[%d] shutdown_timeout:[%s] private_key_path:[%s] public_key_location:[%s]",
-		cfg.HTTPConfig.Port, cfg.HTTPConfig.ShutdownTimeout, cfg.PrivateKeyPath, cfg.PublicKeyLocation)
+	return fmt.Sprintf("port:[%d] shutdown_timeout:[%s] private_key_path:[%s] public_key_location:[%s] notifier_list:[%s]",
+		cfg.HTTPConfig.Port, cfg.HTTPConfig.ShutdownTimeout, cfg.PrivateKeyPath, cfg.PublicKeyLocation, cfg.NotifierList)
 }
 
 func loadVerificationKeyList(location string) ([]*jose.JSONWebKey, error) {

--- a/pkg/common/configuration/config.go
+++ b/pkg/common/configuration/config.go
@@ -29,8 +29,9 @@ type Config struct {
 	// To specify a URL: "url://https://sandbox-api.openbank.stone.com.br/api/v1/discovery/keys"
 	PublicKeyLocation   string `envconfig:"PUBLIC_KEY_PATH" default:"url://https://sandbox-api.openbank.stone.com.br/api/v1/discovery/keys"`
 	VerificationKeyList []*jose.JSONWebKey
-	NotifierList        string `envconfig:"NOTIFIER_LIST" default:"stdout"`
-	ProxyNotifier       ProxyNotifierConfig
+	// NotifierList has stdout and proxy option.
+	NotifierList  string `envconfig:"NOTIFIER_LIST" default:"stdout"`
+	ProxyNotifier ProxyNotifierConfig
 }
 
 type HTTPConfig struct {
@@ -39,7 +40,8 @@ type HTTPConfig struct {
 }
 
 type ProxyNotifierConfig struct {
-	APIUrl string `envconfig:"PROXY_NOTIFIER_API_URL"`
+	Url     string        `envconfig:"PROXY_NOTIFIER_URL"`
+	Timeout time.Duration `envconfig:"PROXY_NOTIFIER_TIMEOUT" default:"10s"`
 }
 
 func LoadConfig() (*Config, error) {

--- a/pkg/common/configuration/config.go
+++ b/pkg/common/configuration/config.go
@@ -62,6 +62,11 @@ func LoadConfig() (*Config, error) {
 	return &config, nil
 }
 
+func (cfg Config) String() string {
+	return fmt.Sprintf("port:[%d] shutdown_timeout:[%s] private_key_path:[%s] public_key_location:[%s]",
+		cfg.HTTPConfig.Port, cfg.HTTPConfig.ShutdownTimeout, cfg.PrivateKeyPath, cfg.PublicKeyLocation)
+}
+
 func loadVerificationKeyList(location string) ([]*jose.JSONWebKey, error) {
 	var keyList []*jose.JSONWebKey
 	var err error

--- a/pkg/common/configuration/config.go
+++ b/pkg/common/configuration/config.go
@@ -1,35 +1,21 @@
 package configuration
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/url"
-	"strings"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
-	"github.com/stone-co/webhook-consumer/pkg/common/keys"
-	"gopkg.in/square/go-jose.v2"
-)
-
-const (
-	FileLocation = "file://"
-	URLLocation  = "url://"
 )
 
 // Config defines the service configuration
 type Config struct {
 	HTTPConfig     HTTPConfig
 	PrivateKeyPath string `envconfig:"PRIVATE_KEY_PATH" default:"tests/partner/fakekey.pem"`
-	PrivateKey     interface{}
 	// PublicKeyLocation can be used to specify a file or a URL.
 	// To specify a file: "file://./tests/stone/fakekey1.pub.jwt"
 	// To specify a URL: "url://https://sandbox-api.openbank.stone.com.br/api/v1/discovery/keys"
-	PublicKeyLocation   string `envconfig:"PUBLIC_KEY_PATH" default:"url://https://sandbox-api.openbank.stone.com.br/api/v1/discovery/keys"`
-	VerificationKeyList []*jose.JSONWebKey
-	// NotifierList has stdout and proxy option.
+	PublicKeyLocation string `envconfig:"PUBLIC_KEY_PATH" default:"url://https://sandbox-api.openbank.stone.com.br/api/v1/discovery/keys"`
+	// NotifierList has stdout and proxy availables.
 	NotifierList  string `envconfig:"NOTIFIER_LIST" default:"stdout"`
 	ProxyNotifier ProxyNotifierConfig
 }
@@ -52,106 +38,10 @@ func LoadConfig() (*Config, error) {
 		return nil, err
 	}
 
-	keyBytes, err := ioutil.ReadFile(config.PrivateKeyPath)
-	if err != nil {
-		return nil, fmt.Errorf("reading file %s: %v", config.PrivateKeyPath, err)
-	}
-
-	config.PrivateKey, err = keys.LoadPrivateKey(keyBytes)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read private key: %v", err)
-	}
-
-	config.VerificationKeyList, err = loadVerificationKeyList(config.PublicKeyLocation)
-	if err != nil {
-		return nil, fmt.Errorf("loading verification key %s: %v", config.PublicKeyLocation, err)
-	}
-
 	return &config, nil
 }
 
 func (cfg Config) String() string {
 	return fmt.Sprintf("port:[%d] shutdown_timeout:[%s] private_key_path:[%s] public_key_location:[%s] notifier_list:[%s]",
 		cfg.HTTPConfig.Port, cfg.HTTPConfig.ShutdownTimeout, cfg.PrivateKeyPath, cfg.PublicKeyLocation, cfg.NotifierList)
-}
-
-func loadVerificationKeyList(location string) ([]*jose.JSONWebKey, error) {
-	var keyList []*jose.JSONWebKey
-	var err error
-
-	if strings.HasPrefix(location, FileLocation) {
-		keyList, err = loadVerificationKeyListFromFile(strings.TrimPrefix(location, FileLocation))
-		if err != nil {
-			return nil, fmt.Errorf("loading verification key from file %s: %v", location, err)
-		}
-	} else if strings.HasPrefix(location, URLLocation) {
-		keyList, err = loadVerificationKeyListFromURL(strings.TrimPrefix(location, URLLocation))
-		if err != nil {
-			return nil, fmt.Errorf("loading verification key from file %s: %v", location, err)
-		}
-	} else {
-		return nil, fmt.Errorf("invalid public key location: %s", location)
-	}
-
-	if len(keyList) == 0 {
-		return nil, fmt.Errorf("empty key list")
-	}
-
-	return keyList, nil
-}
-
-func loadVerificationKeyListFromFile(fileList string) ([]*jose.JSONWebKey, error) {
-	result := []*jose.JSONWebKey{}
-	for _, file := range strings.Split(fileList, ";") {
-		file = strings.TrimSpace(file)
-		if file == "" {
-			break
-		}
-		keyBytes, err := ioutil.ReadFile(file)
-		if err != nil {
-			return nil, fmt.Errorf("reading file %s: %v", file, err)
-		}
-
-		verificationKey, err := keys.LoadPublicKeyFromJWK(keyBytes)
-		if err != nil {
-			return nil, fmt.Errorf("unable to read public key: %v", err)
-		}
-		result = append(result, verificationKey)
-	}
-
-	if result == nil {
-		return nil, fmt.Errorf("empty file list")
-	}
-
-	return result, nil
-}
-
-func loadVerificationKeyListFromURL(serviceURL string) ([]*jose.JSONWebKey, error) {
-	keysURL, err := url.Parse(serviceURL)
-	if err != nil {
-		return nil, fmt.Errorf("unable to parse url %s: %v", serviceURL, err)
-	}
-
-	client := http.DefaultClient
-	response, err := client.Get(keysURL.String())
-	if err != nil {
-		return nil, fmt.Errorf("unable to get url keys %s: %v", keysURL.String(), err)
-	}
-	defer response.Body.Close()
-
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read body: %v", err)
-	}
-
-	type responseBody struct {
-		Keys []*jose.JSONWebKey `json:"keys"`
-	}
-
-	var r responseBody
-	if err = json.Unmarshal(body, &r); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal body: %v", err)
-	}
-
-	return r.Keys, nil
 }

--- a/pkg/common/keys/load_keys.go
+++ b/pkg/common/keys/load_keys.go
@@ -1,0 +1,103 @@
+package keys
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+
+	"gopkg.in/square/go-jose.v2"
+)
+
+// LoadPrivateKey loads a private key from PEM/DER/JWK-encoded data.
+func LoadPrivateKey(data []byte) (interface{}, error) {
+	input := data
+
+	block, _ := pem.Decode(data)
+	if block != nil {
+		input = block.Bytes
+	}
+
+	var priv interface{}
+	priv, err0 := x509.ParsePKCS1PrivateKey(input)
+	if err0 == nil {
+		return priv, nil
+	}
+
+	priv, err1 := x509.ParsePKCS8PrivateKey(input)
+	if err1 == nil {
+		return priv, nil
+	}
+
+	priv, err2 := x509.ParseECPrivateKey(input)
+	if err2 == nil {
+		return priv, nil
+	}
+
+	jwk, err3 := LoadJSONWebKey(input, false)
+	if err3 == nil {
+		return jwk, nil
+	}
+
+	return nil, fmt.Errorf("square/go-jose: parse error, got '%s', '%s', '%s' and '%s'", err0, err1, err2, err3)
+}
+
+func LoadJSONWebKey(json []byte, pub bool) (*jose.JSONWebKey, error) {
+	var jwk jose.JSONWebKey
+	err := jwk.UnmarshalJSON(json)
+	if err != nil {
+		return nil, err
+	}
+
+	if !jwk.Valid() {
+		return nil, errors.New("invalid JWK key")
+	}
+
+	if jwk.IsPublic() != pub {
+		return nil, errors.New("priv/pub JWK key mismatch")
+	}
+
+	return &jwk, nil
+}
+
+// LoadPublicKey loads a public key from PEM/DER/JWK-encoded data.
+func LoadPublicKey(data []byte) (interface{}, error) {
+	input := data
+
+	block, _ := pem.Decode(data)
+	if block != nil {
+		input = block.Bytes
+	}
+
+	var aggErr error
+
+	// Try to load SubjectPublicKeyInfo
+	pub, err := x509.ParsePKIXPublicKey(input)
+	if err == nil {
+		return pub, nil
+	}
+	aggErr = err
+
+	cert, err := x509.ParseCertificate(input)
+	if err == nil {
+		return cert.PublicKey, nil
+	}
+	aggErr = fmt.Errorf("%s: %w", aggErr, err)
+
+	jwk, err := LoadJSONWebKey(data, true)
+	if err == nil {
+		return jwk, nil
+	}
+
+	return nil, fmt.Errorf("%s: %w", aggErr, err)
+}
+
+// LoadPublicKeyFromJWK loads a public key from JWK-encoded data.
+func LoadPublicKeyFromJWK(data []byte) (*jose.JSONWebKey, error) {
+	jwk, err := LoadJSONWebKey(data, true)
+	if err == nil {
+		return jwk, nil
+	}
+
+	return nil, fmt.Errorf("square/go-jose: jwk parse error, got '%s'", err)
+}

--- a/pkg/domain/notification_usecase.go
+++ b/pkg/domain/notification_usecase.go
@@ -5,8 +5,8 @@ import (
 )
 
 type NotificationInput struct {
-	Header HeaderNotification
-	Body   string
+	Header        HeaderNotification
+	EncryptedBody string
 }
 
 type HeaderNotification struct {

--- a/pkg/domain/notifier.go
+++ b/pkg/domain/notifier.go
@@ -3,10 +3,11 @@ package domain
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stone-co/webhook-consumer/pkg/common/configuration"
 )
 
 type Notifier interface {
-	Configure(config *configuration.Config) error
+	Configure(config *configuration.Config, log *logrus.Logger) error
 	Send(ctx context.Context, input NotificationInput) error
 }

--- a/pkg/domain/notifier.go
+++ b/pkg/domain/notifier.go
@@ -9,5 +9,5 @@ import (
 
 type Notifier interface {
 	Configure(config *configuration.Config, log *logrus.Logger) error
-	Send(ctx context.Context, input NotificationInput) error
+	Send(ctx context.Context, eventTypeHeader, eventIDHeader, body string) error
 }

--- a/pkg/domain/notifier_method.go
+++ b/pkg/domain/notifier_method.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stone-co/webhook-consumer/pkg/common/configuration"
 )
 
-type NotifierMethod interface {
+type Notifier interface {
 	Configure(config *configuration.Config) error
 	Send(ctx context.Context, input NotificationInput) error
 }

--- a/pkg/domain/notifier_method.go
+++ b/pkg/domain/notifier_method.go
@@ -2,8 +2,11 @@ package domain
 
 import (
 	"context"
+
+	"github.com/stone-co/webhook-consumer/pkg/common/configuration"
 )
 
 type NotifierMethod interface {
+	Configure(config *configuration.Config) error
 	Send(ctx context.Context, input NotificationInput) error
 }

--- a/pkg/domain/usecase/notification_usecase.go
+++ b/pkg/domain/usecase/notification_usecase.go
@@ -9,13 +9,13 @@ import (
 var _ domain.NotificationUsecase = &NotificationUsecase{}
 
 type NotificationUsecase struct {
-	log    *logrus.Logger
-	method domain.NotifierMethod
+	log     *logrus.Logger
+	methods []domain.NotifierMethod
 }
 
-func NewNotificationUsecase(log *logrus.Logger, method domain.NotifierMethod) *NotificationUsecase {
+func NewNotificationUsecase(log *logrus.Logger, methods []domain.NotifierMethod) *NotificationUsecase {
 	return &NotificationUsecase{
-		log:    log,
-		method: method,
+		log:     log,
+		methods: methods,
 	}
 }

--- a/pkg/domain/usecase/notification_usecase.go
+++ b/pkg/domain/usecase/notification_usecase.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"github.com/sirupsen/logrus"
 
+	"github.com/stone-co/webhook-consumer/pkg/common/keys"
 	"github.com/stone-co/webhook-consumer/pkg/domain"
 )
 
@@ -10,12 +11,14 @@ var _ domain.NotificationUsecase = &NotificationUsecase{}
 
 type NotificationUsecase struct {
 	log       *logrus.Logger
+	keys      *keys.Config
 	notifiers []domain.Notifier
 }
 
-func NewNotificationUsecase(log *logrus.Logger, notifiers []domain.Notifier) *NotificationUsecase {
+func NewNotificationUsecase(log *logrus.Logger, keys *keys.Config, notifiers []domain.Notifier) *NotificationUsecase {
 	return &NotificationUsecase{
 		log:       log,
+		keys:      keys,
 		notifiers: notifiers,
 	}
 }

--- a/pkg/domain/usecase/notification_usecase.go
+++ b/pkg/domain/usecase/notification_usecase.go
@@ -9,13 +9,13 @@ import (
 var _ domain.NotificationUsecase = &NotificationUsecase{}
 
 type NotificationUsecase struct {
-	log     *logrus.Logger
-	methods []domain.NotifierMethod
+	log       *logrus.Logger
+	notifiers []domain.Notifier
 }
 
-func NewNotificationUsecase(log *logrus.Logger, methods []domain.NotifierMethod) *NotificationUsecase {
+func NewNotificationUsecase(log *logrus.Logger, notifiers []domain.Notifier) *NotificationUsecase {
 	return &NotificationUsecase{
-		log:     log,
-		methods: methods,
+		log:       log,
+		notifiers: notifiers,
 	}
 }

--- a/pkg/domain/usecase/send_notification.go
+++ b/pkg/domain/usecase/send_notification.go
@@ -7,8 +7,8 @@ import (
 )
 
 func (uc NotificationUsecase) SendNotification(ctx context.Context, input domain.NotificationInput) error {
-	for _, method := range uc.methods {
-		err := method.Send(ctx, input)
+	for _, notifier := range uc.notifiers {
+		err := notifier.Send(ctx, input)
 		if err != nil {
 			return err
 		}

--- a/pkg/domain/usecase/send_notification.go
+++ b/pkg/domain/usecase/send_notification.go
@@ -2,17 +2,74 @@ package usecase
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/stone-co/webhook-consumer/pkg/domain"
+	"gopkg.in/square/go-jose.v2"
 )
 
 func (uc NotificationUsecase) SendNotification(ctx context.Context, input domain.NotificationInput) error {
+	encryptedPayload, err := uc.verify(input.EncryptedBody)
+	if err != nil {
+		return fmt.Errorf("unable to verify signature: %v", err)
+	}
+
+	payload, err := uc.decode(encryptedPayload)
+	if err != nil {
+		return fmt.Errorf("unable to decode payload: %v", err)
+	}
+
 	for _, notifier := range uc.notifiers {
-		err := notifier.Send(ctx, input)
+		err := notifier.Send(ctx, input.Header.EventType, input.Header.EventID, payload)
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (uc NotificationUsecase) verify(signedBody string) (string, error) {
+	obj, err := jose.ParseSigned(signedBody)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse message: %v", err)
+	}
+
+	if len(obj.Signatures) != 1 {
+		return "", fmt.Errorf("multi signature not supported")
+	}
+
+	// Verify will all keys.
+	var plainText []byte
+	for _, verificationKey := range uc.keys.VerificationKeyList {
+		plainText, err = obj.Verify(verificationKey)
+		if err == nil {
+			break
+		}
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("invalid signature: %v", err)
+	}
+
+	return string(plainText), nil
+}
+
+func (uc NotificationUsecase) decode(encryptedBody string) (string, error) {
+	// Parse the serialized, encrypted JWE object. An error would indicate that
+	// the given input did not represent a valid message.
+	object, err := jose.ParseEncrypted(encryptedBody)
+	if err != nil {
+		return "", fmt.Errorf("parsing encrypted: %v", err)
+	}
+
+	// Now we can decrypt and get back our original plaintext. An error here
+	// would indicate the the message failed to decrypt, e.g. because the auth
+	// tag was broken or the message was tampered with.
+	decrypted, err := object.Decrypt(uc.keys.PrivateKey)
+	if err != nil {
+		return "", fmt.Errorf("decrypting: %v", err)
+	}
+
+	return string(decrypted), nil
 }

--- a/pkg/domain/usecase/send_notification.go
+++ b/pkg/domain/usecase/send_notification.go
@@ -7,6 +7,12 @@ import (
 )
 
 func (uc NotificationUsecase) SendNotification(ctx context.Context, input domain.NotificationInput) error {
-	err := uc.method.Send(ctx, input)
-	return err
+	for _, method := range uc.methods {
+		err := method.Send(ctx, input)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/gateways/http/api.go
+++ b/pkg/gateways/http/api.go
@@ -10,16 +10,17 @@ import (
 	"github.com/urfave/negroni"
 
 	"github.com/stone-co/webhook-consumer/pkg/common/configuration"
+	"github.com/stone-co/webhook-consumer/pkg/common/keys"
 	"github.com/stone-co/webhook-consumer/pkg/common/validator"
 	"github.com/stone-co/webhook-consumer/pkg/domain"
 	"github.com/stone-co/webhook-consumer/pkg/gateways/http/healthcheck"
 	"github.com/stone-co/webhook-consumer/pkg/gateways/http/notifications"
 )
 
-func NewHttpServer(config configuration.Config, log *logrus.Logger, usecase domain.NotificationUsecase) *http.Server {
+func NewHttpServer(config configuration.Config, keys *keys.Config, log *logrus.Logger, usecase domain.NotificationUsecase) *http.Server {
 	validator := validator.NewJSONValidator()
 
-	notificationsHandler := notifications.NewHandler(log, validator, config.PrivateKey, config.VerificationKeyList, usecase)
+	notificationsHandler := notifications.NewHandler(log, validator, keys, usecase)
 
 	api := NewApi(log, notificationsHandler)
 	return api.NewServer("0.0.0.0", config.HTTPConfig)

--- a/pkg/gateways/http/api.go
+++ b/pkg/gateways/http/api.go
@@ -10,17 +10,16 @@ import (
 	"github.com/urfave/negroni"
 
 	"github.com/stone-co/webhook-consumer/pkg/common/configuration"
-	"github.com/stone-co/webhook-consumer/pkg/common/keys"
 	"github.com/stone-co/webhook-consumer/pkg/common/validator"
 	"github.com/stone-co/webhook-consumer/pkg/domain"
 	"github.com/stone-co/webhook-consumer/pkg/gateways/http/healthcheck"
 	"github.com/stone-co/webhook-consumer/pkg/gateways/http/notifications"
 )
 
-func NewHttpServer(config configuration.Config, keys *keys.Config, log *logrus.Logger, usecase domain.NotificationUsecase) *http.Server {
+func NewHttpServer(config configuration.Config, log *logrus.Logger, usecase domain.NotificationUsecase) *http.Server {
 	validator := validator.NewJSONValidator()
 
-	notificationsHandler := notifications.NewHandler(log, validator, keys, usecase)
+	notificationsHandler := notifications.NewHandler(log, validator, usecase)
 
 	api := NewApi(log, notificationsHandler)
 	return api.NewServer("0.0.0.0", config.HTTPConfig)

--- a/pkg/gateways/http/notifications/new_notification.go
+++ b/pkg/gateways/http/notifications/new_notification.go
@@ -35,6 +35,13 @@ func (h Handler) New(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check for mandatory headers.
+	if r.Header.Get(EventIDHeader) == "" || r.Header.Get(EventTypeHeader) == "" {
+		h.log.Errorf("%s and %s headers are mandatories", EventIDHeader, EventTypeHeader)
+		_ = responses.SendError(w, fmt.Sprintf("%s and %s headers are mandatories", EventIDHeader, EventTypeHeader), http.StatusBadRequest)
+		return
+	}
+
 	encryptedPayload, err := h.verify(encryptedBody.EncryptedBody)
 	if err != nil {
 		h.log.WithError(err).Error("invalid signature")

--- a/pkg/gateways/http/notifications/new_notification.go
+++ b/pkg/gateways/http/notifications/new_notification.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stone-co/webhook-consumer/pkg/domain"
 	"github.com/stone-co/webhook-consumer/pkg/gateways/http/responses"
-	"gopkg.in/square/go-jose.v2"
 )
 
 const (
@@ -42,80 +41,20 @@ func (h Handler) New(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	encryptedPayload, err := h.verify(encryptedBody.EncryptedBody)
-	if err != nil {
-		h.log.WithError(err).Error("invalid signature")
-		_ = responses.SendError(w, err.Error(), http.StatusForbidden)
-		return
-	}
-
-	payload, err := h.decode(encryptedPayload)
-	if err != nil {
-		h.log.WithError(err).Error("invalid payload")
-		_ = responses.SendError(w, err.Error(), http.StatusForbidden)
-		return
-	}
-
 	input := domain.NotificationInput{
 		Header: domain.HeaderNotification{
 			EventID:   r.Header.Get(EventIDHeader),
 			EventType: r.Header.Get(EventTypeHeader),
 		},
-		Body: payload,
+		EncryptedBody: encryptedBody.EncryptedBody,
 	}
 
 	// Call the usecase.
-	err = h.usecase.SendNotification(r.Context(), input)
-	if err != nil {
+	if err := h.usecase.SendNotification(r.Context(), input); err != nil {
 		h.log.WithError(err).Error("failed to send notification")
-		_ = responses.SendError(w, "failed to send notification", http.StatusInternalServerError)
+		_ = responses.SendError(w, "failed to send notification", http.StatusForbidden)
 		return
 	}
 
 	_ = responses.Send(w, nil, http.StatusNoContent)
-}
-
-func (h Handler) verify(signedBody string) (string, error) {
-	obj, err := jose.ParseSigned(signedBody)
-	if err != nil {
-		return "", fmt.Errorf("unable to parse message: %v", err)
-	}
-
-	if len(obj.Signatures) != 1 {
-		return "", fmt.Errorf("multi signature not supported")
-	}
-
-	// Verify will all keys.
-	var plainText []byte
-	for _, verificationKey := range h.keys.VerificationKeyList {
-		plainText, err = obj.Verify(verificationKey)
-		if err == nil {
-			break
-		}
-	}
-
-	if err != nil {
-		return "", fmt.Errorf("invalid signature: %v", err)
-	}
-
-	return string(plainText), nil
-}
-
-func (h Handler) decode(encryptedBody string) (string, error) {
-	// Parse the serialized, encrypted JWE object. An error would indicate that
-	// the given input did not represent a valid message.
-	object, err := jose.ParseEncrypted(encryptedBody)
-	if err != nil {
-		return "", fmt.Errorf("parsing encrypted: %v", err)
-	}
-
-	// Now we can decrypt and get back our original plaintext. An error here
-	// would indicate the the message failed to decrypt, e.g. because the auth
-	// tag was broken or the message was tampered with.
-	decrypted, err := object.Decrypt(h.keys.PrivateKey)
-	if err != nil {
-		return "", fmt.Errorf("decrypting: %v", err)
-	}
-
-	return string(decrypted), nil
 }

--- a/pkg/gateways/http/notifications/new_notification.go
+++ b/pkg/gateways/http/notifications/new_notification.go
@@ -87,7 +87,7 @@ func (h Handler) verify(signedBody string) (string, error) {
 
 	// Verify will all keys.
 	var plainText []byte
-	for _, verificationKey := range h.verificationKeyList {
+	for _, verificationKey := range h.keys.VerificationKeyList {
 		plainText, err = obj.Verify(verificationKey)
 		if err == nil {
 			break
@@ -112,7 +112,7 @@ func (h Handler) decode(encryptedBody string) (string, error) {
 	// Now we can decrypt and get back our original plaintext. An error here
 	// would indicate the the message failed to decrypt, e.g. because the auth
 	// tag was broken or the message was tampered with.
-	decrypted, err := object.Decrypt(h.privateKey)
+	decrypted, err := object.Decrypt(h.keys.PrivateKey)
 	if err != nil {
 		return "", fmt.Errorf("decrypting: %v", err)
 	}

--- a/pkg/gateways/http/notifications/notifications.go
+++ b/pkg/gateways/http/notifications/notifications.go
@@ -3,7 +3,6 @@ package notifications
 import (
 	"github.com/sirupsen/logrus"
 
-	"github.com/stone-co/webhook-consumer/pkg/common/keys"
 	"github.com/stone-co/webhook-consumer/pkg/common/validator"
 	"github.com/stone-co/webhook-consumer/pkg/domain"
 )
@@ -11,15 +10,13 @@ import (
 type Handler struct {
 	log *logrus.Logger
 	*validator.JSONValidator
-	keys    *keys.Config
 	usecase domain.NotificationUsecase
 }
 
-func NewHandler(log *logrus.Logger, validator *validator.JSONValidator, keys *keys.Config, usecase domain.NotificationUsecase) *Handler {
+func NewHandler(log *logrus.Logger, validator *validator.JSONValidator, usecase domain.NotificationUsecase) *Handler {
 	return &Handler{
 		log:           log,
 		JSONValidator: validator,
-		keys:          keys,
 		usecase:       usecase,
 	}
 }

--- a/pkg/gateways/http/notifications/notifications.go
+++ b/pkg/gateways/http/notifications/notifications.go
@@ -2,8 +2,8 @@ package notifications
 
 import (
 	"github.com/sirupsen/logrus"
-	"gopkg.in/square/go-jose.v2"
 
+	"github.com/stone-co/webhook-consumer/pkg/common/keys"
 	"github.com/stone-co/webhook-consumer/pkg/common/validator"
 	"github.com/stone-co/webhook-consumer/pkg/domain"
 )
@@ -11,17 +11,15 @@ import (
 type Handler struct {
 	log *logrus.Logger
 	*validator.JSONValidator
-	privateKey          interface{}
-	verificationKeyList []*jose.JSONWebKey
-	usecase             domain.NotificationUsecase
+	keys    *keys.Config
+	usecase domain.NotificationUsecase
 }
 
-func NewHandler(log *logrus.Logger, validator *validator.JSONValidator, privateKey interface{}, verificationKeyList []*jose.JSONWebKey, usecase domain.NotificationUsecase) *Handler {
+func NewHandler(log *logrus.Logger, validator *validator.JSONValidator, keys *keys.Config, usecase domain.NotificationUsecase) *Handler {
 	return &Handler{
-		log:                 log,
-		JSONValidator:       validator,
-		privateKey:          privateKey,
-		verificationKeyList: verificationKeyList,
-		usecase:             usecase,
+		log:           log,
+		JSONValidator: validator,
+		keys:          keys,
+		usecase:       usecase,
 	}
 }

--- a/pkg/gateways/notifiers/proxy/proxy.go
+++ b/pkg/gateways/notifiers/proxy/proxy.go
@@ -22,13 +22,11 @@ type ProxyNotifier struct {
 	timeout    time.Duration
 }
 
-func New(log *logrus.Logger) *ProxyNotifier {
-	return &ProxyNotifier{
-		log: log,
-	}
+func New() *ProxyNotifier {
+	return &ProxyNotifier{}
 }
 
-func (n *ProxyNotifier) Configure(config *configuration.Config) error {
+func (n *ProxyNotifier) Configure(config *configuration.Config, log *logrus.Logger) error {
 	var err error
 
 	n.timeout = config.ProxyNotifier.Timeout
@@ -36,6 +34,7 @@ func (n *ProxyNotifier) Configure(config *configuration.Config) error {
 	if err != nil || config.ProxyNotifier.Url == "" {
 		return fmt.Errorf("failed to parse url '%s': %v", config.ProxyNotifier.Url, err)
 	}
+	n.log = log
 
 	n.log.WithField("notifier", "proxy").Infof("url:[%s] timeout:[%s]", config.ProxyNotifier.Url, n.timeout.String())
 

--- a/pkg/gateways/notifiers/proxy/proxy.go
+++ b/pkg/gateways/notifiers/proxy/proxy.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stone-co/webhook-consumer/pkg/gateways/http/notifications"
 )
 
-var _ domain.NotifierMethod = &ProxyNotifier{}
+var _ domain.Notifier = &ProxyNotifier{}
 
 type ProxyNotifier struct {
 	log        *logrus.Logger

--- a/pkg/gateways/notifiers/proxy/proxy.go
+++ b/pkg/gateways/notifiers/proxy/proxy.go
@@ -1,0 +1,74 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stone-co/webhook-consumer/pkg/common/configuration"
+	"github.com/stone-co/webhook-consumer/pkg/domain"
+	"github.com/stone-co/webhook-consumer/pkg/gateways/http/notifications"
+)
+
+var _ domain.NotifierMethod = &ProxyNotifier{}
+
+type ProxyNotifier struct {
+	log        *logrus.Logger
+	serviceURL *url.URL
+	timeout    time.Duration
+}
+
+func New(log *logrus.Logger) *ProxyNotifier {
+	return &ProxyNotifier{
+		log: log,
+	}
+}
+
+func (n *ProxyNotifier) Configure(config *configuration.Config) error {
+	var err error
+
+	n.timeout = config.ProxyNotifier.Timeout
+	n.serviceURL, err = url.Parse(config.ProxyNotifier.Url)
+	if err != nil || config.ProxyNotifier.Url == "" {
+		return fmt.Errorf("failed to parse url '%s': %v", config.ProxyNotifier.Url, err)
+	}
+
+	return nil
+}
+
+func (n ProxyNotifier) Send(ctx context.Context, input domain.NotificationInput) error {
+	log := n.log.WithField("notifier", "proxy")
+
+	req, err := http.NewRequest(http.MethodPost, n.serviceURL.String(), strings.NewReader(input.Body))
+	if err != nil {
+		log.Infof("unable to create a request: %w", err)
+		return fmt.Errorf("unable to create a request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(notifications.EventIDHeader, input.Header.EventID)
+	req.Header.Set(notifications.EventTypeHeader, input.Header.EventType)
+
+	client := &http.Client{
+		Timeout: n.timeout,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Infof("unable to send request to service: %v", err)
+		return fmt.Errorf("unable to send request to service: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		log.Infof("unexpected status code when send request to service: %d", resp.StatusCode)
+		return fmt.Errorf("unexpected status code when send request to service: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/gateways/notifiers/proxy/proxy.go
+++ b/pkg/gateways/notifiers/proxy/proxy.go
@@ -46,7 +46,7 @@ func (n ProxyNotifier) Send(ctx context.Context, input domain.NotificationInput)
 
 	req, err := http.NewRequest(http.MethodPost, n.serviceURL.String(), strings.NewReader(input.Body))
 	if err != nil {
-		log.Infof("unable to create a request: %w", err)
+		log.WithError(err).Info("unable to create a request")
 		return fmt.Errorf("unable to create a request: %w", err)
 	}
 
@@ -60,7 +60,7 @@ func (n ProxyNotifier) Send(ctx context.Context, input domain.NotificationInput)
 
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Infof("unable to send request to service: %v", err)
+		log.WithError(err).Info("unable to send request to service")
 		return fmt.Errorf("unable to send request to service: %v", err)
 	}
 

--- a/pkg/gateways/notifiers/proxy/proxy.go
+++ b/pkg/gateways/notifiers/proxy/proxy.go
@@ -41,18 +41,18 @@ func (n *ProxyNotifier) Configure(config *configuration.Config, log *logrus.Logg
 	return nil
 }
 
-func (n ProxyNotifier) Send(ctx context.Context, input domain.NotificationInput) error {
+func (n ProxyNotifier) Send(ctx context.Context, eventTypeHeader, eventIDHeader, body string) error {
 	log := n.log.WithField("notifier", "proxy")
 
-	req, err := http.NewRequest(http.MethodPost, n.serviceURL.String(), strings.NewReader(input.Body))
+	req, err := http.NewRequest(http.MethodPost, n.serviceURL.String(), strings.NewReader(body))
 	if err != nil {
 		log.WithError(err).Info("unable to create a request")
 		return fmt.Errorf("unable to create a request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set(notifications.EventIDHeader, input.Header.EventID)
-	req.Header.Set(notifications.EventTypeHeader, input.Header.EventType)
+	req.Header.Set(notifications.EventIDHeader, eventIDHeader)
+	req.Header.Set(notifications.EventTypeHeader, eventTypeHeader)
 
 	client := &http.Client{
 		Timeout: n.timeout,

--- a/pkg/gateways/notifiers/proxy/proxy.go
+++ b/pkg/gateways/notifiers/proxy/proxy.go
@@ -37,6 +37,8 @@ func (n *ProxyNotifier) Configure(config *configuration.Config) error {
 		return fmt.Errorf("failed to parse url '%s': %v", config.ProxyNotifier.Url, err)
 	}
 
+	n.log.WithField("notifier", "proxy").Infof("url:[%s] timeout:[%s]", config.ProxyNotifier.Url, n.timeout.String())
+
 	return nil
 }
 

--- a/pkg/gateways/notifiers/stdout/stdout.go
+++ b/pkg/gateways/notifiers/stdout/stdout.go
@@ -4,25 +4,30 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
-
+	"github.com/stone-co/webhook-consumer/pkg/common/configuration"
 	"github.com/stone-co/webhook-consumer/pkg/domain"
 )
 
-var _ domain.NotifierMethod = &Stdout{}
+var _ domain.NotifierMethod = &StdoutNotifier{}
 
-type Stdout struct {
+type StdoutNotifier struct {
 	log *logrus.Logger
 }
 
-func New(log *logrus.Logger) *Stdout {
-	return &Stdout{
+func New(log *logrus.Logger) *StdoutNotifier {
+	return &StdoutNotifier{
 		log: log,
 	}
 }
 
-func (std Stdout) Send(ctx context.Context, input domain.NotificationInput) error {
-	std.log.Printf("Body: %s\n", input.Body)
-	std.log.Printf("Header: %+v\n", input.Header)
+func (n StdoutNotifier) Configure(config *configuration.Config) error {
+	return nil
+}
+
+func (n StdoutNotifier) Send(ctx context.Context, input domain.NotificationInput) error {
+	log := n.log.WithField("notifier", "stdout")
+	log.Printf("Body: %s\n", input.Body)
+	log.Printf("Header: %+v\n", input.Header)
 
 	return nil
 }

--- a/pkg/gateways/notifiers/stdout/stdout.go
+++ b/pkg/gateways/notifiers/stdout/stdout.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stone-co/webhook-consumer/pkg/domain"
 )
 
-var _ domain.NotifierMethod = &StdoutNotifier{}
+var _ domain.Notifier = &StdoutNotifier{}
 
 type StdoutNotifier struct {
 	log *logrus.Logger

--- a/pkg/gateways/notifiers/stdout/stdout.go
+++ b/pkg/gateways/notifiers/stdout/stdout.go
@@ -14,13 +14,12 @@ type StdoutNotifier struct {
 	log *logrus.Logger
 }
 
-func New(log *logrus.Logger) *StdoutNotifier {
-	return &StdoutNotifier{
-		log: log,
-	}
+func New() *StdoutNotifier {
+	return &StdoutNotifier{}
 }
 
-func (n StdoutNotifier) Configure(config *configuration.Config) error {
+func (n *StdoutNotifier) Configure(config *configuration.Config, log *logrus.Logger) error {
+	n.log = log
 	return nil
 }
 

--- a/pkg/gateways/notifiers/stdout/stdout.go
+++ b/pkg/gateways/notifiers/stdout/stdout.go
@@ -23,10 +23,10 @@ func (n *StdoutNotifier) Configure(config *configuration.Config, log *logrus.Log
 	return nil
 }
 
-func (n StdoutNotifier) Send(ctx context.Context, input domain.NotificationInput) error {
+func (n StdoutNotifier) Send(ctx context.Context, eventTypeHeader, eventIDHeader, body string) error {
 	log := n.log.WithField("notifier", "stdout")
-	log.Printf("Body: %s\n", input.Body)
-	log.Printf("Header: %+v\n", input.Header)
+	log.Printf("event headers: type[%s] id[%s]\n", eventTypeHeader, eventIDHeader)
+	log.Printf("body: %s\n", body)
 
 	return nil
 }


### PR DESCRIPTION
Proxy notifier can send notifications to other services.

* feat: all notifiers must implement the configure method
* feat: check for mandatory stone headers
* feat: receive a list of notifiers to be executed
* feat: log config when starting
* refact: usecase deal with decrypt and signature
* refact: split between env configs and keys info