### PR TITLE
Feat/redis notifier

### DIFF
--- a/cmd/define_notifiers_test.go
+++ b/cmd/define_notifiers_test.go
@@ -23,6 +23,11 @@ func Test_extractNotifiersFromConfig(t *testing.T) {
 			want: []string{"stdout", "proxy"},
 		},
 		{
+			name: "Valid config with three notifiers",
+			args: "stdout;proxy;redis",
+			want: []string{"stdout", "proxy", "redis"},
+		},
+		{
 			name: "Config is case insensitive",
 			args: "stDOut;PROxy",
 			want: []string{"stdout", "proxy"},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,7 +30,7 @@ func main() {
 		log.WithError(err).Fatal("unable to load keys")
 	}
 
-	notifiers, err := defineNotifiers(cfg, log)
+	notifiers, err := defineNotifiers(cfg.NotifierList, log)
 	if err != nil {
 		log.WithError(err).Fatalf("unable to define notifiers: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.15
 
 require (
 	github.com/go-playground/validator/v10 v10.4.1
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/gomodule/redigo v1.8.3
 	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -13,7 +15,8 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/urfave/negroni v1.0.0
-	golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 // indirect
+	golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9 // indirect
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,10 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
+github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/gomodule/redigo v1.8.3 h1:HR0kYDX2RJZvAup8CsiJwxB4dTCSC0AaUq6S4SiLwUc=
+github.com/gomodule/redigo v1.8.3/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -109,6 +113,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/urfave/negroni v1.0.0 h1:kIimOitoypq34K7TG7DUaJ9kq/N4Ofuwi1sjz0KipXc=
@@ -117,6 +122,8 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9 h1:umElSU9WZirRdgu2yFHY0ayQkEnKiOC1TtM3fWXFnoU=
+golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -143,8 +150,8 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 h1:bNEHhJCnrwMKNMmOx3yAynp5vs5/gRy+XWFtZFu7NBM=
-golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
+golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/pkg/common/configuration/config.go
+++ b/pkg/common/configuration/config.go
@@ -16,18 +16,12 @@ type Config struct {
 	// To specify a URL: "url://https://sandbox-api.openbank.stone.com.br/api/v1/discovery/keys"
 	PublicKeyLocation string `envconfig:"PUBLIC_KEY_PATH" default:"url://https://sandbox-api.openbank.stone.com.br/api/v1/discovery/keys"`
 	// NotifierList has stdout and proxy availables.
-	NotifierList  string `envconfig:"NOTIFIER_LIST" default:"stdout"`
-	ProxyNotifier ProxyNotifierConfig
+	NotifierList string `envconfig:"NOTIFIER_LIST" default:"stdout"`
 }
 
 type HTTPConfig struct {
 	Port            int           `envconfig:"API_PORT" default:"3000"`
 	ShutdownTimeout time.Duration `envconfig:"API_SHUTDOWN_TIMEOUT" default:"5s"`
-}
-
-type ProxyNotifierConfig struct {
-	Url     string        `envconfig:"PROXY_NOTIFIER_URL"`
-	Timeout time.Duration `envconfig:"PROXY_NOTIFIER_TIMEOUT" default:"10s"`
 }
 
 func LoadConfig() (*Config, error) {

--- a/pkg/domain/notifier.go
+++ b/pkg/domain/notifier.go
@@ -4,10 +4,9 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
-	"github.com/stone-co/webhook-consumer/pkg/common/configuration"
 )
 
 type Notifier interface {
-	Configure(config *configuration.Config, log *logrus.Logger) error
+	Configure(log *logrus.Logger) error
 	Send(ctx context.Context, eventTypeHeader, eventIDHeader, body string) error
 }

--- a/pkg/gateways/notifiers/proxy/configure.go
+++ b/pkg/gateways/notifiers/proxy/configure.go
@@ -1,0 +1,40 @@
+package proxy
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/sirupsen/logrus"
+)
+
+type Config struct {
+	Url     string        `envconfig:"PROXY_NOTIFIER_URL"`
+	Timeout time.Duration `envconfig:"PROXY_NOTIFIER_TIMEOUT" default:"10s"`
+}
+
+func (n *ProxyNotifier) Configure(log *logrus.Logger) error {
+	var config Config
+	prefix := ""
+	if err := envconfig.Process(prefix, &config); err != nil {
+		return err
+	}
+
+	n.log = log
+	log.WithField("notifier", "proxy").Infof("config:[%+v]", config)
+
+	var err error
+
+	n.timeout = config.Timeout
+	n.serviceURL, err = url.Parse(config.Url)
+	if err != nil || config.Url == "" {
+		return fmt.Errorf("failed to parse url '%s': %v", config.Url, err)
+	}
+	n.log = log
+
+	n.log.WithField("notifier", "proxy").Infof("url:[%s] timeout:[%s]", config.Url, n.timeout.String())
+
+	return nil
+
+}

--- a/pkg/gateways/notifiers/proxy/proxy.go
+++ b/pkg/gateways/notifiers/proxy/proxy.go
@@ -1,17 +1,11 @@
 package proxy
 
 import (
-	"context"
-	"fmt"
-	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"github.com/stone-co/webhook-consumer/pkg/common/configuration"
 	"github.com/stone-co/webhook-consumer/pkg/domain"
-	"github.com/stone-co/webhook-consumer/pkg/gateways/http/notifications"
 )
 
 var _ domain.Notifier = &ProxyNotifier{}
@@ -24,52 +18,4 @@ type ProxyNotifier struct {
 
 func New() *ProxyNotifier {
 	return &ProxyNotifier{}
-}
-
-func (n *ProxyNotifier) Configure(config *configuration.Config, log *logrus.Logger) error {
-	var err error
-
-	n.timeout = config.ProxyNotifier.Timeout
-	n.serviceURL, err = url.Parse(config.ProxyNotifier.Url)
-	if err != nil || config.ProxyNotifier.Url == "" {
-		return fmt.Errorf("failed to parse url '%s': %v", config.ProxyNotifier.Url, err)
-	}
-	n.log = log
-
-	n.log.WithField("notifier", "proxy").Infof("url:[%s] timeout:[%s]", config.ProxyNotifier.Url, n.timeout.String())
-
-	return nil
-}
-
-func (n ProxyNotifier) Send(ctx context.Context, eventTypeHeader, eventIDHeader, body string) error {
-	log := n.log.WithField("notifier", "proxy")
-
-	req, err := http.NewRequest(http.MethodPost, n.serviceURL.String(), strings.NewReader(body))
-	if err != nil {
-		log.WithError(err).Info("unable to create a request")
-		return fmt.Errorf("unable to create a request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set(notifications.EventIDHeader, eventIDHeader)
-	req.Header.Set(notifications.EventTypeHeader, eventTypeHeader)
-
-	client := &http.Client{
-		Timeout: n.timeout,
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		log.WithError(err).Info("unable to send request to service")
-		return fmt.Errorf("unable to send request to service: %v", err)
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		log.Infof("unexpected status code when send request to service: %d", resp.StatusCode)
-		return fmt.Errorf("unexpected status code when send request to service: %d", resp.StatusCode)
-	}
-
-	return nil
 }

--- a/pkg/gateways/notifiers/proxy/send_notification.go
+++ b/pkg/gateways/notifiers/proxy/send_notification.go
@@ -1,0 +1,43 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/stone-co/webhook-consumer/pkg/gateways/http/notifications"
+)
+
+func (n ProxyNotifier) Send(ctx context.Context, eventTypeHeader, eventIDHeader, body string) error {
+	log := n.log.WithField("notifier", "proxy")
+
+	req, err := http.NewRequest(http.MethodPost, n.serviceURL.String(), strings.NewReader(body))
+	if err != nil {
+		log.WithError(err).Info("unable to create a request")
+		return fmt.Errorf("unable to create a request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(notifications.EventIDHeader, eventIDHeader)
+	req.Header.Set(notifications.EventTypeHeader, eventTypeHeader)
+
+	client := &http.Client{
+		Timeout: n.timeout,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.WithError(err).Info("unable to send request to service")
+		return fmt.Errorf("unable to send request to service: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		log.Infof("unexpected status code when send request to service: %d", resp.StatusCode)
+		return fmt.Errorf("unexpected status code when send request to service: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/gateways/notifiers/redis/config.go
+++ b/pkg/gateways/notifiers/redis/config.go
@@ -1,0 +1,77 @@
+package redis
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+)
+
+type Config struct {
+	Address            string        `envconfig:"REDIS_ADDR" required:"true"`
+	Port               string        `envconfig:"REDIS_PORT" required:"true"`
+	Password           string        `envconfig:"REDIS_PASSWORD"`
+	UseTLS             bool          `envconfig:"REDIS_USE_TLS" default:"false"`
+	MaxIdle            int           `envconfig:"REDIS_MAX_IDLE" default:"100"`
+	MaxActive          int           `envconfig:"REDIS_MAX_ACTIVE" default:"1000"`
+	IdleTimeout        time.Duration `envconfig:"REDIS_IDLE_TIMEOUT" default:"1m"`
+	DialConnectTimeout time.Duration `envconfig:"REDIS_CONNECT_TIMEOUT" default:"1s"`
+	DialReadTimeout    time.Duration `envconfig:"REDIS_READ_TIMEOUT" default:"300ms"`
+	DialWriteTimeout   time.Duration `envconfig:"REDIS_WRITE_TIMEOUT" default:"300ms"`
+}
+
+func (c Config) Addr() string {
+	return strings.Join([]string{c.Address, c.Port}, ":")
+}
+
+func (c Config) URL() string {
+	scheme := "redis"
+	if c.UseTLS {
+		scheme = "rediss"
+	}
+	addr := c.Addr()
+	if c.Password != "" {
+		addr = fmt.Sprintf(":%s@%s", c.Password, addr)
+	}
+	return fmt.Sprintf("%s://%s", scheme, addr)
+}
+
+func initPool(cfg Config) (*redis.Pool, error) {
+	redisPool := &redis.Pool{
+		MaxIdle:     cfg.MaxIdle,
+		MaxActive:   cfg.MaxActive,
+		IdleTimeout: cfg.IdleTimeout,
+		Dial: func() (redis.Conn, error) {
+			conn, err := redis.Dial("tcp", cfg.Addr(),
+				redis.DialPassword(cfg.Password),
+				redis.DialUseTLS(cfg.UseTLS),
+				redis.DialConnectTimeout(cfg.DialConnectTimeout),
+				redis.DialReadTimeout(cfg.DialReadTimeout),
+				redis.DialWriteTimeout(cfg.DialWriteTimeout))
+			if err != nil {
+				return nil, fmt.Errorf("could not connect to redis: %w", err)
+			}
+			return conn, nil
+		},
+	}
+
+	err := ping(redisPool)
+	if err != nil {
+		return nil, err
+	}
+
+	return redisPool, nil
+}
+
+func ping(pool *redis.Pool) error {
+	conn := pool.Get()
+	defer conn.Close()
+
+	_, err := redis.String(conn.Do("PING"))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/gateways/notifiers/redis/configure.go
+++ b/pkg/gateways/notifiers/redis/configure.go
@@ -1,0 +1,25 @@
+package redis
+
+import (
+	"github.com/kelseyhightower/envconfig"
+	"github.com/sirupsen/logrus"
+)
+
+func (n *RedisNotifier) Configure(log *logrus.Logger) error {
+	var config Config
+	prefix := ""
+	if err := envconfig.Process(prefix, &config); err != nil {
+		return err
+	}
+
+	n.log = log
+	log.WithField("notifier", "redis").Infof("config:[%+v]", config)
+
+	var err error
+	n.pool, err = initPool(config)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/gateways/notifiers/redis/redis.go
+++ b/pkg/gateways/notifiers/redis/redis.go
@@ -1,0 +1,18 @@
+package redis
+
+import (
+	"github.com/gomodule/redigo/redis"
+	"github.com/sirupsen/logrus"
+	"github.com/stone-co/webhook-consumer/pkg/domain"
+)
+
+var _ domain.Notifier = &RedisNotifier{}
+
+type RedisNotifier struct {
+	log  *logrus.Logger
+	pool *redis.Pool
+}
+
+func New() *RedisNotifier {
+	return &RedisNotifier{}
+}

--- a/pkg/gateways/notifiers/redis/send_notification.go
+++ b/pkg/gateways/notifiers/redis/send_notification.go
@@ -1,0 +1,44 @@
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	RedisNotificationList = "STONE-NOTIFICATIONS"
+)
+
+type Notification struct {
+	EventType string
+	EventID   string
+	Body      json.RawMessage
+}
+
+func (n RedisNotifier) Send(ctx context.Context, eventTypeHeader, eventIDHeader, body string) error {
+	log := n.log.WithField("notifier", "redis")
+
+	conn := n.pool.Get()
+	defer conn.Close()
+
+	notification := Notification{
+		EventType: eventTypeHeader,
+		EventID:   eventIDHeader,
+		Body:      []byte(body),
+	}
+
+	encoded, err := json.Marshal(notification)
+	if err != nil {
+		log.WithError(err).Error("failed to marshal notification")
+		return fmt.Errorf("failed to marshal notification: %w", err)
+	}
+
+	_, err = conn.Do("RPUSH", RedisNotificationList, encoded)
+	if err != nil {
+		log.WithError(err).Info("unable to save the notifier")
+		return fmt.Errorf("unable to save the notifier: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/gateways/notifiers/stdout/configure.go
+++ b/pkg/gateways/notifiers/stdout/configure.go
@@ -1,0 +1,11 @@
+package stdout
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+func (n *StdoutNotifier) Configure(log *logrus.Logger) error {
+	n.log = log
+
+	return nil
+}

--- a/pkg/gateways/notifiers/stdout/send_notification.go
+++ b/pkg/gateways/notifiers/stdout/send_notification.go
@@ -1,0 +1,13 @@
+package stdout
+
+import (
+	"context"
+)
+
+func (n StdoutNotifier) Send(ctx context.Context, eventTypeHeader, eventIDHeader, body string) error {
+	log := n.log.WithField("notifier", "stdout")
+	log.Printf("event headers: type[%s] id[%s]\n", eventTypeHeader, eventIDHeader)
+	log.Printf("body: %s\n", body)
+
+	return nil
+}

--- a/pkg/gateways/notifiers/stdout/stdout.go
+++ b/pkg/gateways/notifiers/stdout/stdout.go
@@ -1,10 +1,7 @@
 package stdout
 
 import (
-	"context"
-
 	"github.com/sirupsen/logrus"
-	"github.com/stone-co/webhook-consumer/pkg/common/configuration"
 	"github.com/stone-co/webhook-consumer/pkg/domain"
 )
 
@@ -16,17 +13,4 @@ type StdoutNotifier struct {
 
 func New() *StdoutNotifier {
 	return &StdoutNotifier{}
-}
-
-func (n *StdoutNotifier) Configure(config *configuration.Config, log *logrus.Logger) error {
-	n.log = log
-	return nil
-}
-
-func (n StdoutNotifier) Send(ctx context.Context, eventTypeHeader, eventIDHeader, body string) error {
-	log := n.log.WithField("notifier", "stdout")
-	log.Printf("event headers: type[%s] id[%s]\n", eventTypeHeader, eventIDHeader)
-	log.Printf("body: %s\n", body)
-
-	return nil
 }


### PR DESCRIPTION
Hello :-)

In this PR was implemented the Redis Notifier. There are a lot of optional configs to use Redis, but the requireds configs are two:

- REDIS_ADDR
- REDIS_PORT

This config is loaded when the redis notifier is listed on notifiers list. For example:

export NOTIFIER_LIST="stdout;redis"

And, if necessary, is possible to enable all notifiers:

export NOTIFIER_LIST="stdout;redis;proxy"

At this time, all notifiers are executed sequentially. There is a task to address this ASAP, I mean, send all notifications in parallel.