### PR TITLE
feat: add dockerfile and readme to usage with docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-build/
+build/*
+!build/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,13 @@ test:
 
 .PHONY: compile
 compile: clean
-	@echo "==> Go Building WebHookConsumer"
+	@echo "==> Go Building webhook-consumer"
 	@env GOOS=${OS} GOARCH=amd64 go build -v -o build/${NAME} ${PKG}/
+
+.PHONY: build
+build: compile
+	@echo "==> Building Docker image to webhook-consumer"
+	@docker build -t ${REGISTRY}/${NAME}:${VERSION} build -f build/Dockerfile
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -52,3 +52,29 @@ $ ./build/webhook-consumer
 
 At this time, just a simple notifier was implemented (stdout).
 After start the webhook, is possible to make a call and the data will be printed on the stdout.
+
+### Usage with Docker
+
+First build the Docker Image, or get at Docker Hub.
+```bash
+$ make build
+```
+
+Now create a container with volume to your certificate file, and a environment
+variable `PRIVATE_KEY_PATH` to your _.pem_ file.
+```bash
+$ docker run -v $(pwd)/tests:/usr/share/certificates -e PRIVATE_KEY_PATH="/usr/share/certificates/partner/fakekey.pem" -d stone-co/webhook-consumer:dev
+```
+
+Environment variables, and default values:
+
+- PUBLIC_KEY_PATH="tests/partner/fakekey.pem"
+- NOTIFIER_LIST="url://https://sandbox-api.openbank.stone.com.br/api/v1/discovery/keys"
+- API_PORT="3000"
+- API_SHUTDOWN_TIMEOUT="5s"
+
+you can pass environment variable with -e flat to docker container run.
+
+```
+-e API_PORT="3000"
+```

--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ $ docker run -v $(pwd)/tests:/usr/share/certificates -e PRIVATE_KEY_PATH="/usr/s
 
 Environment variables, and default values:
 
-- PUBLIC_KEY_PATH="tests/partner/fakekey.pem"
-- NOTIFIER_LIST="url://https://sandbox-api.openbank.stone.com.br/api/v1/discovery/keys"
+- PRIVATE_KEY_PATH="tests/partner/fakekey.pem"
+- PUBLIC_KEY_PATH="url://https://sandbox-api.openbank.stone.com.br/api/v1/discovery/keys"
+- NOTIFIER_LIST=stdout
 - API_PORT="3000"
 - API_SHUTDOWN_TIMEOUT="5s"
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:20.04
+
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install locales tzdata openssl ca-certificates -y \
+    && /usr/sbin/update-ca-certificates \
+    && locale-gen en_US.UTF-8 pt_BR.UTF-8
+
+ENV	LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8 DEBIAN_FRONTEND=noninteractive
+
+ADD webhook-consumer /bin/
+
+ENTRYPOINT ["/bin/webhook-consumer"]


### PR DESCRIPTION
Add [Dockerfile](https://github.com/juceliofloresta/webhook-consumer/blob/feat/dockerfile/build/Dockerfile) to container running support. 

The user can pass environment variables to certificates path with a docker voulme too, and running in your infrastructure.

For example:

Now create a container with volume to your certificate file, and a environment
variable `PRIVATE_KEY_PATH` to your _.pem_ file.
```bash
$ docker run -v $(pwd)/tests:/usr/share/certificates -e PRIVATE_KEY_PATH="/usr/share/certificates/partner/fakekey.pem" -d stone-co/webhook-consumer:dev
```
code above are in Readme.md too. 

![image](https://user-images.githubusercontent.com/10274274/116756508-9dcb9500-a9e2-11eb-871e-fc1a95f5b82f.png)
